### PR TITLE
auto open youtube tabs

### DIFF
--- a/app/src/service-worker/polling/index.ts
+++ b/app/src/service-worker/polling/index.ts
@@ -19,7 +19,7 @@ import {
   getYouTubeLogin,
   sortChannels,
 } from 'src/utils';
-import { openTwitchTabs } from '../tabs';
+import { openTwitchTabs, openYoutubeTabs } from '../tabs';
 import { fetchTwitchData, handleError as handleTwitchError } from './twitch';
 import { fetchData as fetchKickData } from './kick';
 import {
@@ -151,6 +151,7 @@ async function fetchData() {
   }
   // TODO: Support auto opening tabs with YouTube
   if (youtubeApiKey || youtubeLogin) {
+    log("trying youtube");
     try {
       // Only use the accessToken to fetch data if it comes from a custom app
       const options: FetchYouTubeDataOptions | null = youtubeLogin?.clientId && youtubeLogin?.clientSecret ? {
@@ -190,7 +191,10 @@ async function fetchData() {
   await setChannels(newChannels);
   youtubeLogin = getYouTubeLogin(storage); // get the login again because the accessToken and expiry may have been updated
   if (youtubeLogin) tryPollYouTubeSubscriptions(youtubeLogin)?.catch(error);
-  if (autoOpenTabs) openTwitchTabs(newChannels);
+  if (autoOpenTabs) {
+    openTwitchTabs(newChannels);
+    openYoutubeTabs(newChannels);
+  }
 }
 
 async function poll() {

--- a/app/src/service-worker/polling/index.ts
+++ b/app/src/service-worker/polling/index.ts
@@ -151,7 +151,6 @@ async function fetchData() {
   }
   // TODO: Support auto opening tabs with YouTube
   if (youtubeApiKey || youtubeLogin) {
-    log("trying youtube");
     try {
       // Only use the accessToken to fetch data if it comes from a custom app
       const options: FetchYouTubeDataOptions | null = youtubeLogin?.clientId && youtubeLogin?.clientSecret ? {

--- a/app/src/service-worker/tabs.ts
+++ b/app/src/service-worker/tabs.ts
@@ -199,6 +199,7 @@ export async function openYoutubeTabs(channels: Channel[]) {
     .filter((c): c is LiveYouTubeChannel => Boolean(c.viewerCount) && getFavoritesIncludesChannel(favorites, c))
     .sort((a, b) => sortChannels(a, b, favorites));
 
+  // for youtube this would also include various other yt videos as it is the same structure, so really "maxStreams" becomes "maxYoutubeVideosOrStreams" pretty much
   const tabs = await getYoutubeVideoTabs();
   const openVideoIds = tabs.map(tab => {
       if(tab.url) {

--- a/app/src/service-worker/utils.ts
+++ b/app/src/service-worker/utils.ts
@@ -4,7 +4,9 @@ import { ORIGINS } from 'src/app-constants';
 import { IntentionalAny, OriginType } from 'src/types';
 
 const TWITCH_HOSTNAME_REGEX = /^(www.|m.)?twitch.tv$/i;
+const YOUTUBE_HOSTNAME_REGES = /^(www.|m.)?youtube.com$/i;
 const TWITCH_CHANNEL_PATH_REGEX = /^\/(?!(videos\/\d+|[^/]+\/clip\/.+|settings|popout|subscriptions|wallet|inventory|drops|directory))/i;
+const YOUTUBE_VIDEO_REGEX = /^\/watch/i;
 const TWITCH_LOCKED_TAB_REGEX = /^\/(moderator\/.+)|([^/]+\/(videos|clips?|schedule|about))/i;
 
 /**
@@ -29,6 +31,12 @@ export function isUrlTwitchChannel(url: string): boolean {
   const { hostname, pathname } = new URL(url);
   return TWITCH_HOSTNAME_REGEX.test(hostname)
     && TWITCH_CHANNEL_PATH_REGEX.test(pathname);
+}
+
+export function isUrlYoutubeVideo(url: string): boolean {
+  const {hostname, pathname } = new URL(url);
+  return YOUTUBE_HOSTNAME_REGES.test(hostname)
+    && YOUTUBE_VIDEO_REGEX.test(pathname)
 }
 
 /**

--- a/app/src/service-worker/utils.ts
+++ b/app/src/service-worker/utils.ts
@@ -4,7 +4,7 @@ import { ORIGINS } from 'src/app-constants';
 import { IntentionalAny, OriginType } from 'src/types';
 
 const TWITCH_HOSTNAME_REGEX = /^(www.|m.)?twitch.tv$/i;
-const YOUTUBE_HOSTNAME_REGES = /^(www.|m.)?youtube.com$/i;
+const YOUTUBE_HOSTNAME_REGEX = /^(www.|m.)?youtube.com$/i;
 const TWITCH_CHANNEL_PATH_REGEX = /^\/(?!(videos\/\d+|[^/]+\/clip\/.+|settings|popout|subscriptions|wallet|inventory|drops|directory))/i;
 const YOUTUBE_VIDEO_REGEX = /^\/watch/i;
 const TWITCH_LOCKED_TAB_REGEX = /^\/(moderator\/.+)|([^/]+\/(videos|clips?|schedule|about))/i;
@@ -35,7 +35,7 @@ export function isUrlTwitchChannel(url: string): boolean {
 
 export function isUrlYoutubeVideo(url: string): boolean {
   const {hostname, pathname } = new URL(url);
-  return YOUTUBE_HOSTNAME_REGES.test(hostname)
+  return YOUTUBE_HOSTNAME_REGEX.test(hostname)
     && YOUTUBE_VIDEO_REGEX.test(pathname)
 }
 


### PR DESCRIPTION
Super cool plugin, I had the idea of making something similar specifically for youtube and came across your plugin in my initial research to see if it had already been done before :) 

This is just an initial setup and definitely isn't as robust as the initial twitch stuff that was already in place:

- hiding channels doesn't seem to be an option with YT accounts, so remove need for dealing with those
- wasn't entirely sure what the meaning was behind the "replaceable" tabs and such for twitch so excluded that. Really just look to see if tab already open and if so don't reopen it. Figure if something was inactive or anything that a user could just manually close it and/or open other additional streams quickly from their list if they so choose
- `maxStreams` - see comment details about how it isn't combined for twitch/yt at the moment

Tested a few things locally in chrome build: 
- does in fact open a favorite YT stream added via "add channels" and then favorited
- doesn't open favorites if already have maxStreams of youtube streams (or videos) open